### PR TITLE
Fixed the issue with checkbox stretch in phones

### DIFF
--- a/dristhi-app/assets/css/alerts.css
+++ b/dristhi-app/assets/css/alerts.css
@@ -5,8 +5,8 @@
 }
 
 .alert .todo-box {
-    width: 55px;
-    height: 55px;
+    width: 41px;
+    height: 41px;
 }
 
 .alert.overdue {
@@ -52,9 +52,13 @@
 }
 
 .alert-todo-message {
-    margin-top: 10px;
+    margin-top: auto;
 }
 
+.alert-todo-message .detail {
+	display: inline-block;
+	vertical-align: -50%;
+}
 .alert-todo {
     margin-bottom: 8px;
 }


### PR DESCRIPTION
Known issue: Margins on beneficiaryName, husbandName, dueDate make the checkboxes seem like floating in the middle. Could be fixed removing the margins. 
